### PR TITLE
Fix lesson 14 double-escaped pattern

### DIFF
--- a/data/curriculum.ts
+++ b/data/curriculum.ts
@@ -275,7 +275,7 @@ export const curriculum: Module[] = [
           { text: 'cat', shouldMatch: false },
           { text: 'the cat', shouldMatch: false }
         ],
-        solution: '\\\\Bcat',
+        solution: '\\Bcat',
         hints: [
           'Use \\B for non-word boundaries',
           'Match "cat" within a word, not at the start',


### PR DESCRIPTION
## Summary
• Fixed lesson 14 (Non-Word Boundary) where pattern was double-escaped as `'\\\\Bcat'` instead of `'\\Bcat'`
• This was causing inverted validation results in the UI

## Test plan
- [x] Verified pattern `\Bcat` correctly matches "locate" and "educate" (should match)
- [x] Verified pattern `\Bcat` correctly does NOT match "cat" and "the cat" (should not match)
- [x] Confirmed application builds successfully
- [x] Tested regex validation works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)